### PR TITLE
BaseRtpEndpoint: Discard media from unknown SSRC missing from SDP

### DIFF
--- a/src/gst-plugins/commons/kmsbasertpendpoint.c
+++ b/src/gst-plugins/commons/kmsbasertpendpoint.c
@@ -901,7 +901,7 @@ kms_base_rtp_endpoint_request_rtp_sink (KmsIRtpSessionManager * manager,
     KmsBaseRtpSession * sess, const GstSDPMedia * media)
 {
   KmsBaseRtpEndpoint *self = KMS_BASE_RTP_ENDPOINT (manager);
-  const gchar *media_str = gst_sdp_media_get_media (media);
+  const gchar *media_str = media ? gst_sdp_media_get_media (media) : NULL;
   GstPad *pad;
 
   if (g_strcmp0 (AUDIO_STREAM_NAME, media_str) == 0) {
@@ -913,8 +913,15 @@ kms_base_rtp_endpoint_request_rtp_sink (KmsIRtpSessionManager * manager,
         gst_element_get_request_pad (self->priv->rtpbin,
         VIDEO_RTPBIN_RECV_RTP_SINK);
   } else {
-    GST_ERROR_OBJECT (self, "'%s' not valid", media_str);
-    return NULL;
+    GST_WARNING_OBJECT (self, "Unknown Media RTP will be discarded: '%s'",
+        GST_STR_NULL (media_str));
+
+    GstElement *fakesink =
+        kms_utils_element_factory_make ("fakesink", "basertpendpoint");
+    g_object_set (fakesink, "async", FALSE, "sync", FALSE, NULL);
+    gst_bin_add (GST_BIN (self), fakesink);
+    gst_element_sync_state_with_parent (fakesink);
+    pad = gst_element_get_static_pad (fakesink, "sink");
   }
 
   return pad;
@@ -967,7 +974,7 @@ kms_base_rtp_endpoint_request_rtcp_sink (KmsIRtpSessionManager * manager,
     KmsBaseRtpSession * sess, const GstSDPMedia * media)
 {
   KmsBaseRtpEndpoint *self = KMS_BASE_RTP_ENDPOINT (manager);
-  const gchar *media_str = gst_sdp_media_get_media (media);
+  const gchar *media_str = media ? gst_sdp_media_get_media (media) : NULL;
   GstPad *pad;
 
   if (g_strcmp0 (AUDIO_STREAM_NAME, media_str) == 0) {
@@ -979,8 +986,15 @@ kms_base_rtp_endpoint_request_rtcp_sink (KmsIRtpSessionManager * manager,
         gst_element_get_request_pad (self->priv->rtpbin,
         VIDEO_RTPBIN_RECV_RTCP_SINK);
   } else {
-    GST_ERROR_OBJECT (self, "'%s' not valid", media_str);
-    return NULL;
+    GST_WARNING_OBJECT (self, "Unknown Media RTCP will be discarded: '%s'",
+        GST_STR_NULL (media_str));
+
+    GstElement *fakesink =
+        kms_utils_element_factory_make ("fakesink", "basertpendpoint");
+    g_object_set (fakesink, "async", FALSE, "sync", FALSE, NULL);
+    gst_bin_add (GST_BIN (self), fakesink);
+    gst_element_sync_state_with_parent (fakesink);
+    pad = gst_element_get_static_pad (fakesink, "sink");
   }
 
   return pad;

--- a/src/gst-plugins/commons/kmsbasertpsession.c
+++ b/src/gst-plugins/commons/kmsbasertpsession.c
@@ -326,11 +326,15 @@ rtp_ssrc_demux_new_ssrc_pad (GstElement * ssrcdemux, guint ssrc, GstPad * pad,
       || ssrcs_are_mapped (ssrcdemux, self->local_video_ssrc, ssrc)) {
     media = self->video_neg;
   } else {
-    if (!kms_i_rtp_session_manager_custom_ssrc_management (self->manager, self,
+    if (kms_i_rtp_session_manager_custom_ssrc_management (self->manager, self,
             ssrcdemux, ssrc, pad)) {
-      GST_ERROR_OBJECT (pad, "SSRC %" G_GUINT32_FORMAT " not matching.", ssrc);
+      goto end;
+    } else {
+      GST_WARNING_OBJECT (pad,
+          "Ignoring media from non-matching SSRC: %" G_GUINT32_FORMAT, ssrc);
+
+      media = NULL;
     }
-    goto end;
   }
 
   /* RTP */

--- a/src/gst-plugins/commons/kmsirtpsessionmanager.c
+++ b/src/gst-plugins/commons/kmsirtpsessionmanager.c
@@ -71,9 +71,12 @@ kms_i_rtp_session_manager_custom_ssrc_management (KmsIRtpSessionManager * self,
     KmsBaseRtpSession * sess, GstElement * ssrcdemux, guint ssrc, GstPad * pad)
 {
   g_return_val_if_fail (KMS_IS_I_RTP_SESSION_MANAGER (self), FALSE);
-  g_return_val_if_fail (KMS_I_RTP_SESSION_MANAGER_GET_INTERFACE (self)->
-      custom_ssrc_management, FALSE);
-    
+
+  if (!KMS_I_RTP_SESSION_MANAGER_GET_INTERFACE (self)->custom_ssrc_management) {
+    // No custom SSRC handler has been installed. Reject the SSRC handling.
+    return FALSE;
+  }
+
   return
       KMS_I_RTP_SESSION_MANAGER_GET_INTERFACE (self)->custom_ssrc_management
       (self, sess, ssrcdemux, ssrc, pad);


### PR DESCRIPTION
When some incoming media's SSRC has not been previously negotiated in
the SDP Offer/Answer, this would cause a Glib assertion error and the
media wouldn't be handled correctly.

Add a fakesink so all unknown SSRC media will be dropped cleanly.